### PR TITLE
Remove deletion of .terraform folder

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-echo "**************************************************";
-echo "Remove remote state .terraform"
-echo "**************************************************";
-rm -rf .terraform
-
 AWS_ACCESS_KEY_VAR=`cat $AWS_ACCESS_KEY_FILE`
 AWS_SECRET_KEY_VAR=`cat $AWS_SECRET_KEY_FILE`
 


### PR DESCRIPTION
It is not possible to work with Terraform modules if the `.terraform` folder
is deleted prior to any Terraform run. It makes running `terraform get`
useless, which is necessary when working with modules.